### PR TITLE
Use the api href and updated_at for the sitemap

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## 2.1 → 2.2
 
-**No breaking changes.** `composer update flyo/nitro-laravel` is enough, no code changes are required in a project.
+**No breaking changes.** `composer update flyo/nitro-laravel` is enough, no code changes are required in a project. It pulls `flyo/nitro-php` 2.2, which is the sdk release exposing the sitemap fields used below.
 
 ### What's new
 
@@ -36,7 +36,7 @@
    <url><loc>https://example.com/news/a-news</loc><lastmod>2025-08-12T14:40:00+00:00</lastmod></url>
    ```
 
-   The timestamp reflects the last time the delivered content of that page or entity actually changed, a rebuild producing identical output does not move it. It requires a `flyo/nitro-php` release generated against the current api schema, older versions of the sdk drop the field and the entries are written without `lastmod` as before.
+   The timestamp reflects the last time the delivered content of that page or entity actually changed, a rebuild producing identical output does not move it. Items the api sends without a timestamp are written without `lastmod`.
 
 5. **The sitemap links the `href` delivered by the api.** Every sitemap item carries the resolved url path of the page or entity, it is used instead of rebuilding the url from `entity_slug` and the `default_route` route.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,10 +30,23 @@
 
    An already published `config/flyo.php` does **not** have to be updated, the CDN url pinned to the major version is used when the key is absent.
 
-4. **Editor messages are no longer handled twice.** Depending on the load order, page refresh and scroll-to-block could be registered twice, so a single message from the editor was handled twice. Page refresh and scroll-to-block also work now when the click-to-edit overlay is unavailable.
+4. **The sitemap sends a `lastmod` for every entry.** The nitro api delivers an `updated_at` unix timestamp per sitemap item, it is rendered as W3C datetime:
+
+   ```xml
+   <url><loc>https://example.com/news/a-news</loc><lastmod>2025-08-12T14:40:00+00:00</lastmod></url>
+   ```
+
+   The timestamp reflects the last time the delivered content of that page or entity actually changed, a rebuild producing identical output does not move it. It requires a `flyo/nitro-php` release generated against the current api schema, older versions of the sdk drop the field and the entries are written without `lastmod` as before.
+
+5. **The sitemap links the `href` delivered by the api.** Every sitemap item carries the resolved url path of the page or entity, it is used instead of rebuilding the url from `entity_slug` and the `default_route` route.
+
+6. **Editor messages are no longer handled twice.** Depending on the load order, page refresh and scroll-to-block could be registered twice, so a single message from the editor was handled twice. Page refresh and scroll-to-block also work now when the click-to-edit overlay is unavailable.
 
 ### Behavior notes
 
 - **The nitro js bridge 1.5.0 is picked up automatically**, because the url is pinned to the major version on the CDN. Its live edit hover affordance was rebuilt: hovering an editable block fades in a highlight ring plus the pencil button, drawn in a single element outside of your markup, so it can not touch your css or your layout. The most visible difference for an editor: **the pencil appears after roughly 0.6s of hovering** instead of instantly, which stops it flickering while the mouse crosses the page. It also can not be styled from your site's css anymore.
 - **The rendered marker lost its surrounding spaces.** `@editable($block)` used to echo `' data-flyo-uid="uid" '`, it now echoes `data-flyo-uid="uid"`. Templates like `<div @editable($block) class="…">` are unaffected, only html snapshot tests could notice.
 - **The `Flyo-Live-Edit` debug response header** sends the string `'1'`/`'0'` instead of the integer `1`/`0`. Identical over the wire.
+- **The sitemap can contain more urls than before.** It used to list an entity only when the route configured in `flyo.default_route` was resolvable for it, now every entity the api resolved a url for is listed. Entities without a resolvable url are still skipped, duplicate urls are listed once. In multi lingual setups the locale prefix is part of the delivered url, urls built from `entity_slug` were missing it.
+- **`flyo.default_route` is no longer read by the package.** The config key stays in `config/flyo.php` so applications using it keep working, the sitemap does not use it anymore.
+- **`SitemapController` takes a `Flyo\Api\SitemapApi`** instead of the config repository and the api configuration, the api client is resolved from the container. Only relevant when the controller was instantiated or extended manually, the route keeps working unchanged.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "flyo/nitro-php": "^2.0",
+        "flyo/nitro-php": "^2.2",
         "laravel/framework": "^11|^12",
         "flyo/nitro-php-bridge": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "961f3dd9cf791f914c9fc37ab55a5685",
+    "content-hash": "b2ea8b602c71b4935af65bb3f163d8e9",
     "packages": [
         {
             "name": "brick/math",
@@ -510,16 +510,16 @@
         },
         {
             "name": "flyo/nitro-php",
-            "version": "2.1.1",
+            "version": "2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flyocloud/nitro-php-sdk.git",
-                "reference": "0ba7b546f64c013dd602c3f286ed99c5dcca3136"
+                "reference": "2257fee63b4756220ef73bf90872ec4a68b2ffb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flyocloud/nitro-php-sdk/zipball/0ba7b546f64c013dd602c3f286ed99c5dcca3136",
-                "reference": "0ba7b546f64c013dd602c3f286ed99c5dcca3136",
+                "url": "https://api.github.com/repos/flyocloud/nitro-php-sdk/zipball/2257fee63b4756220ef73bf90872ec4a68b2ffb2",
+                "reference": "2257fee63b4756220ef73bf90872ec4a68b2ffb2",
                 "shasum": ""
             },
             "require": {
@@ -553,9 +553,9 @@
             ],
             "support": {
                 "issues": "https://github.com/flyocloud/nitro-php-sdk/issues",
-                "source": "https://github.com/flyocloud/nitro-php-sdk/tree/2.1.1"
+                "source": "https://github.com/flyocloud/nitro-php-sdk/tree/2.2"
             },
-            "time": "2026-04-28T17:28:30+00:00"
+            "time": "2026-08-11T18:39:55+00:00"
         },
         {
             "name": "flyo/nitro-php-bridge",

--- a/config/flyo.php
+++ b/config/flyo.php
@@ -31,6 +31,7 @@ return [
 
     // The default route to be used for the detail pages.
     // Routes/Links can be defined in the Flyo interface for each corresponding entity, the default name is 'detail'.
+    // Not used by the package itself, the sitemap uses the url the API resolved for an entity.
     'default_route' => env('FLYO_DEFAULT_ROUTE', 'detail'),
 
     // The list of supported locales as defined in the Flyo interface.

--- a/src/Controllers/SitemapController.php
+++ b/src/Controllers/SitemapController.php
@@ -17,15 +17,12 @@ class SitemapController
     }
 
     /**
-     * The `updated_at` unix timestamp of a sitemap item as `lastmod` value.
-     *
-     * The timestamp is read through the array access of the generated model instead of a getter,
-     * because `getUpdatedAt()` only exists once flyo/nitro-php has been regenerated against the
-     * current openapi schema. Until then the key is absent and the entry is written without lastmod.
+     * The `updated_at` unix timestamp of a sitemap item as `lastmod` value, null when the api did
+     * not deliver a timestamp for the item.
      */
     private function lastmod(EntityinterfaceInner $item): ?string
     {
-        $updatedAt = (int) $item['updated_at'];
+        $updatedAt = (int) $item->getUpdatedAt();
 
         return $updatedAt > 0 ? gmdate(DATE_W3C, $updatedAt) : null;
     }

--- a/src/Controllers/SitemapController.php
+++ b/src/Controllers/SitemapController.php
@@ -3,39 +3,66 @@
 namespace Flyo\Laravel\Controllers;
 
 use Flyo\Api\SitemapApi;
-use Flyo\Configuration;
-use Illuminate\Config\Repository;
+use Flyo\Model\EntityinterfaceInner;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
 class SitemapController
 {
-    public function __construct(protected Repository $repository, protected Response $response, protected Request $request, protected Configuration $config) {}
+    public function __construct(protected Response $response, protected Request $request, protected SitemapApi $api) {}
 
-    private function buildUrl($path)
+    private function buildUrl(string $path): string
     {
         return rtrim($this->request->root(), '/').'/'.ltrim($path, '/');
     }
 
+    /**
+     * The `updated_at` unix timestamp of a sitemap item as `lastmod` value.
+     *
+     * The timestamp is read through the array access of the generated model instead of a getter,
+     * because `getUpdatedAt()` only exists once flyo/nitro-php has been regenerated against the
+     * current openapi schema. Until then the key is absent and the entry is written without lastmod.
+     */
+    private function lastmod(EntityinterfaceInner $item): ?string
+    {
+        $updatedAt = (int) $item['updated_at'];
+
+        return $updatedAt > 0 ? gmdate(DATE_W3C, $updatedAt) : null;
+    }
+
     public function render()
     {
-        $detailRoute = $this->repository->get('flyo.default_route', 'detail');
-        $api = new SitemapApi(null, $this->config);
-        $routes = [];
+        $locations = [];
         $xml = '<?xml version="1.0" encoding="UTF-8"?>';
         $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
 
-        foreach ($api->sitemap() as $item) {
+        foreach ($this->api->sitemap() as $item) {
+            // the api resolves the url path of every page and entity into href, including the
+            // locale prefix in multi lingual setups. It is empty when no route could be resolved
+            // for the item, which means it is not reachable and must not show up in the sitemap.
+            $href = $item->getHref();
 
-            if ($item->getEntityType() == 'nitro-page') {
-                if (in_array($item->getEntitySlug(), $routes)) {
-                    continue;
-                }
-                $routes[] = $item->getEntitySlug();
-                $xml .= '<url><loc>'.$this->buildUrl($item->getEntitySlug()).'</loc></url>';
-            } elseif (isset($item->getRoutes()[$detailRoute])) {
-                $xml .= '<url><loc>'.$this->buildUrl($item->getRoutes()[$detailRoute]).'</loc></url>';
+            if (empty($href)) {
+                continue;
             }
+
+            $loc = $this->buildUrl($href);
+
+            // the same location can be delivered more than once, for example when several entities
+            // are mapped to one page
+            if (in_array($loc, $locations, true)) {
+                continue;
+            }
+
+            $locations[] = $loc;
+
+            $xml .= '<url><loc>'.htmlspecialchars($loc, ENT_XML1, 'UTF-8').'</loc>';
+
+            if ($lastmod = $this->lastmod($item)) {
+                $xml .= '<lastmod>'.$lastmod.'</lastmod>';
+            }
+
+            $xml .= '</url>';
         }
 
         $xml .= '</urlset>';

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Flyo\Laravel;
 
 use Flyo\Api\ConfigApi;
 use Flyo\Api\PagesApi;
+use Flyo\Api\SitemapApi;
 use Flyo\Configuration;
 use Flyo\Laravel\Components\Head;
 use Flyo\Laravel\Controllers\SitemapController;
@@ -67,6 +68,10 @@ class ServiceProvider extends SupportServiceProvider
 
             $this->app->singleton(Configuration::class, function () use ($config) {
                 return $config;
+            });
+
+            $this->app->singleton(SitemapApi::class, function () use ($config) {
+                return new SitemapApi(null, $config);
             });
 
             $response = (new ConfigApi(null, $config))->config(App::getLocale());

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Flyo\Laravel\Tests;
+
+use Flyo\Api\SitemapApi;
+use Flyo\Laravel\Controllers\SitemapController;
+use Flyo\Model\EntityinterfaceInner;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class SitemapTest extends TestCase
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function item(array $data): EntityinterfaceInner
+    {
+        $item = new EntityinterfaceInner($data);
+
+        // the generated model drops properties it does not know yet, updated_at is only part of it
+        // once flyo/nitro-php has been regenerated, so it is written into the container directly
+        if (isset($data['updated_at'])) {
+            $item['updated_at'] = $data['updated_at'];
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param  array<int, EntityinterfaceInner>  $items
+     */
+    private function render(array $items): string
+    {
+        $api = $this->createStub(SitemapApi::class);
+        $api->method('sitemap')->willReturn($items);
+
+        $controller = new SitemapController(new Response, Request::create('https://example.com/sitemap.xml'), $api);
+
+        return (string) $controller->render()->getContent();
+    }
+
+    public function test_the_href_of_an_item_is_used_as_absolute_loc(): void
+    {
+        $xml = $this->render([
+            $this->item(['entity_type' => 'nitro-page', 'entity_slug' => 'about', 'href' => '/about']),
+            $this->item(['entity_type' => 'news', 'entity_slug' => 'a-news', 'href' => '/de/news/a-news']),
+        ]);
+
+        $this->assertStringContainsString('<url><loc>https://example.com/about</loc></url>', $xml);
+        $this->assertStringContainsString('<url><loc>https://example.com/de/news/a-news</loc></url>', $xml);
+    }
+
+    public function test_the_updated_at_timestamp_is_rendered_as_lastmod(): void
+    {
+        $xml = $this->render([
+            $this->item(['href' => '/about', 'updated_at' => 1755000000]),
+        ]);
+
+        $this->assertStringContainsString('<loc>https://example.com/about</loc><lastmod>'.gmdate(DATE_W3C, 1755000000).'</lastmod>', $xml);
+    }
+
+    public function test_an_item_without_updated_at_is_rendered_without_lastmod(): void
+    {
+        $xml = $this->render([
+            $this->item(['href' => '/about']),
+            $this->item(['href' => '/contact', 'updated_at' => 0]),
+        ]);
+
+        $this->assertStringNotContainsString('lastmod', $xml);
+    }
+
+    public function test_items_without_a_resolved_href_are_skipped(): void
+    {
+        $xml = $this->render([
+            $this->item(['entity_slug' => 'not-routed', 'routes' => ['_empty' => 'true']]),
+            $this->item(['href' => '', 'entity_slug' => 'also-not-routed']),
+        ]);
+
+        $this->assertStringNotContainsString('<url>', $xml);
+        $this->assertStringNotContainsString('not-routed', $xml);
+    }
+
+    public function test_the_same_location_is_only_listed_once(): void
+    {
+        $xml = $this->render([
+            $this->item(['href' => '/about', 'updated_at' => 1755000000]),
+            $this->item(['href' => '/about', 'updated_at' => 1755000001]),
+        ]);
+
+        $this->assertSame(1, substr_count($xml, '<loc>https://example.com/about</loc>'));
+    }
+
+    public function test_the_response_is_a_valid_xml_urlset(): void
+    {
+        $xml = $this->render([
+            $this->item(['href' => '/foo?a=1&b=2', 'updated_at' => 1755000000]),
+        ]);
+
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', $xml);
+        $this->assertStringEndsWith('</urlset>', $xml);
+        $this->assertStringContainsString('<loc>https://example.com/foo?a=1&amp;b=2</loc>', $xml);
+        $this->assertInstanceOf(\SimpleXMLElement::class, simplexml_load_string($xml));
+    }
+}

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -11,22 +11,6 @@ use Illuminate\Http\Response;
 class SitemapTest extends TestCase
 {
     /**
-     * @param  array<string, mixed>  $data
-     */
-    private function item(array $data): EntityinterfaceInner
-    {
-        $item = new EntityinterfaceInner($data);
-
-        // the generated model drops properties it does not know yet, updated_at is only part of it
-        // once flyo/nitro-php has been regenerated, so it is written into the container directly
-        if (isset($data['updated_at'])) {
-            $item['updated_at'] = $data['updated_at'];
-        }
-
-        return $item;
-    }
-
-    /**
      * @param  array<int, EntityinterfaceInner>  $items
      */
     private function render(array $items): string
@@ -42,8 +26,8 @@ class SitemapTest extends TestCase
     public function test_the_href_of_an_item_is_used_as_absolute_loc(): void
     {
         $xml = $this->render([
-            $this->item(['entity_type' => 'nitro-page', 'entity_slug' => 'about', 'href' => '/about']),
-            $this->item(['entity_type' => 'news', 'entity_slug' => 'a-news', 'href' => '/de/news/a-news']),
+            new EntityinterfaceInner(['entity_type' => 'nitro-page', 'entity_slug' => 'about', 'href' => '/about']),
+            new EntityinterfaceInner(['entity_type' => 'news', 'entity_slug' => 'a-news', 'href' => '/de/news/a-news']),
         ]);
 
         $this->assertStringContainsString('<url><loc>https://example.com/about</loc></url>', $xml);
@@ -53,7 +37,7 @@ class SitemapTest extends TestCase
     public function test_the_updated_at_timestamp_is_rendered_as_lastmod(): void
     {
         $xml = $this->render([
-            $this->item(['href' => '/about', 'updated_at' => 1755000000]),
+            new EntityinterfaceInner(['href' => '/about', 'updated_at' => 1755000000]),
         ]);
 
         $this->assertStringContainsString('<loc>https://example.com/about</loc><lastmod>'.gmdate(DATE_W3C, 1755000000).'</lastmod>', $xml);
@@ -62,8 +46,8 @@ class SitemapTest extends TestCase
     public function test_an_item_without_updated_at_is_rendered_without_lastmod(): void
     {
         $xml = $this->render([
-            $this->item(['href' => '/about']),
-            $this->item(['href' => '/contact', 'updated_at' => 0]),
+            new EntityinterfaceInner(['href' => '/about']),
+            new EntityinterfaceInner(['href' => '/contact', 'updated_at' => 0]),
         ]);
 
         $this->assertStringNotContainsString('lastmod', $xml);
@@ -72,8 +56,8 @@ class SitemapTest extends TestCase
     public function test_items_without_a_resolved_href_are_skipped(): void
     {
         $xml = $this->render([
-            $this->item(['entity_slug' => 'not-routed', 'routes' => ['_empty' => 'true']]),
-            $this->item(['href' => '', 'entity_slug' => 'also-not-routed']),
+            new EntityinterfaceInner(['entity_slug' => 'not-routed']),
+            new EntityinterfaceInner(['href' => '', 'entity_slug' => 'also-not-routed']),
         ]);
 
         $this->assertStringNotContainsString('<url>', $xml);
@@ -83,8 +67,8 @@ class SitemapTest extends TestCase
     public function test_the_same_location_is_only_listed_once(): void
     {
         $xml = $this->render([
-            $this->item(['href' => '/about', 'updated_at' => 1755000000]),
-            $this->item(['href' => '/about', 'updated_at' => 1755000001]),
+            new EntityinterfaceInner(['href' => '/about', 'updated_at' => 1755000000]),
+            new EntityinterfaceInner(['href' => '/about', 'updated_at' => 1755000001]),
         ]);
 
         $this->assertSame(1, substr_count($xml, '<loc>https://example.com/about</loc>'));
@@ -93,7 +77,7 @@ class SitemapTest extends TestCase
     public function test_the_response_is_a_valid_xml_urlset(): void
     {
         $xml = $this->render([
-            $this->item(['href' => '/foo?a=1&b=2', 'updated_at' => 1755000000]),
+            new EntityinterfaceInner(['href' => '/foo?a=1&b=2', 'updated_at' => 1755000000]),
         ]);
 
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', $xml);


### PR DESCRIPTION
The nitro api ([openapi](https://api.flyo.cloud/nitro/v1/openapi)) delivers two things per sitemap item the generator did not use: `href`, the resolved url path of the page or entity, and `updated_at`, a unix timestamp described in the schema as *"Use this value as the `lastmod` information when generating a sitemap"*. `flyo/nitro-php` 2.2 exposes both on the sitemap model, so the requirement is bumped from `^2.0` to `^2.2`.

## What changed

**`lastmod`** — every entry with an `updated_at` gets a `<lastmod>` in W3C datetime:

```xml
<url><loc>https://example.com/news/a-news</loc><lastmod>2025-08-12T14:40:00+00:00</lastmod></url>
```

Per the schema, the timestamp only moves when the delivered content of that page or entity actually changed — a rebuild producing identical output does not move it, so crawlers are not told to recheck everything after every publish.

**`loc`** — the url comes from `href` instead of being rebuilt from `entity_slug` / the `flyo.default_route` route. Two consequences beyond the simpler code: locale prefixes are part of the delivered url (urls built from `entity_slug` were missing them in multi lingual setups), and entities mapped to a route other than `detail` are no longer dropped. Items without an `href` are skipped, duplicate locations are listed once.

Also: `loc` is xml escaped now, so a `&` in a url can not break the document.

## Other

`SitemapController` now receives a `Flyo\Api\SitemapApi` (bound as a singleton in the service provider) instead of building it from the config repository and the api configuration. That makes the rendering testable — `tests/SitemapTest.php` covers the `href` mapping, the `lastmod` formatting, skipping unrouted items, deduplication and the escaping.

`flyo.default_route` is no longer read by the package. The config key is left in place so applications reading it keep working. `UPGRADE.md` documents all of this.

Pint and phpunit pass locally against the 2.2 sdk (32 tests). Phpstan could not run in this environment — `phpstan/phpstan` is distributed as a github zipball only and the sandbox has no access to it, CI covers it.