### PR TITLE
Add tests for entity routes deserialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "flyo/nitro-php": "^2.2",
+        "flyo/nitro-php": "^2.3",
         "laravel/framework": "^11|^12",
         "flyo/nitro-php-bridge": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2ea8b602c71b4935af65bb3f163d8e9",
+    "content-hash": "565e7b79b60b4b1ad26cdbeae39e3963",
     "packages": [
         {
             "name": "brick/math",
@@ -510,16 +510,16 @@
         },
         {
             "name": "flyo/nitro-php",
-            "version": "2.2",
+            "version": "2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flyocloud/nitro-php-sdk.git",
-                "reference": "2257fee63b4756220ef73bf90872ec4a68b2ffb2"
+                "reference": "18325f3ea9c3fa7f8e102be23ac89b78d1d2f2d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flyocloud/nitro-php-sdk/zipball/2257fee63b4756220ef73bf90872ec4a68b2ffb2",
-                "reference": "2257fee63b4756220ef73bf90872ec4a68b2ffb2",
+                "url": "https://api.github.com/repos/flyocloud/nitro-php-sdk/zipball/18325f3ea9c3fa7f8e102be23ac89b78d1d2f2d0",
+                "reference": "18325f3ea9c3fa7f8e102be23ac89b78d1d2f2d0",
                 "shasum": ""
             },
             "require": {
@@ -553,9 +553,9 @@
             ],
             "support": {
                 "issues": "https://github.com/flyocloud/nitro-php-sdk/issues",
-                "source": "https://github.com/flyocloud/nitro-php-sdk/tree/2.2"
+                "source": "https://github.com/flyocloud/nitro-php-sdk/tree/2.3"
             },
-            "time": "2026-08-11T18:39:55+00:00"
+            "time": "2026-08-18T09:10:32+00:00"
         },
         {
             "name": "flyo/nitro-php-bridge",

--- a/tests/EntityRoutesTest.php
+++ b/tests/EntityRoutesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Flyo\Laravel\Tests;
+
+use Flyo\ObjectSerializer;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * The route map of an entity is delivered as a free form object, the api adds the system key
+ * `_empty` to it when no route could be resolved. Both the detail entity and the items of a
+ * list (search, sitemap, blocks) have to deserialize into a plain array, otherwise the
+ * resolved routes never reach userland: while the openapi spec declared `_empty` as a
+ * property of the list item map, the generator turned that map into a model class knowing
+ * only `_empty` and every real route key was dropped (flyo/nitro-php 2.2).
+ */
+class EntityRoutesTest extends TestCase
+{
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function entityClassProvider(): array
+    {
+        return [
+            'detail entity' => ['\Flyo\Model\EntityInterface'],
+            'list item' => ['\Flyo\Model\EntityinterfaceInner'],
+        ];
+    }
+
+    /**
+     * @param  class-string  $class
+     */
+    #[DataProvider('entityClassProvider')]
+    public function test_resolved_routes_are_readable_as_an_array(string $class): void
+    {
+        $entity = ObjectSerializer::deserialize(
+            json_decode('{"entity_slug":"a-slug","routes":{"detail":"/a-section/a-slug"}}'),
+            $class
+        );
+
+        $this->assertSame(['detail' => '/a-section/a-slug'], $entity->getRoutes());
+    }
+
+    /**
+     * @param  class-string  $class
+     */
+    #[DataProvider('entityClassProvider')]
+    public function test_the_empty_marker_of_an_unresolved_route_map_stays_a_boolean(string $class): void
+    {
+        $entity = ObjectSerializer::deserialize(
+            json_decode('{"entity_slug":"a-slug","routes":{"_empty":true}}'),
+            $class
+        );
+
+        $this->assertSame(['_empty' => true], $entity->getRoutes());
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for entity route deserialization to ensure that resolved routes are properly accessible as arrays while preserving the `_empty` marker for unresolved route maps.

## Key Changes
- Added `EntityRoutesTest` class with two test cases covering route deserialization behavior
- Tests verify that resolved routes (e.g., `detail` routes) deserialize into readable arrays
- Tests confirm that the `_empty` boolean marker for unresolved routes is preserved correctly
- Tests cover both detail entities and list items to ensure consistent behavior across entity types
- Updated `flyo/nitro-php` dependency from `^2.2` to `^2.3`

## Notable Implementation Details
The tests address a known issue where the OpenAPI spec declares route maps as free-form objects, but the code generator converts them into model classes. This can cause real route keys to be dropped during deserialization. The tests ensure that:
1. Resolved routes remain accessible as plain arrays in userland code
2. The `_empty` marker (added by the API when no route could be resolved) is preserved as a boolean value
3. Both detail entities and list items handle route deserialization consistently

https://claude.ai/code/session_016E95ZC5VjSHSvSaSdjmvzF